### PR TITLE
ESPHome: update names

### DIFF
--- a/esphome/teleinfokit.yml
+++ b/esphome/teleinfokit.yml
@@ -1,7 +1,7 @@
 # ESPHome configuration file for teleinfokit module https://342apps.net/module-teleinfokit/
 
 esphome:
-  name: teleinfokit_esphome
+  name: teleinfokit
   platform: ESP8266
   board: esp01_1m
 
@@ -14,7 +14,7 @@ wifi:
 
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
-    ssid: "Teleinfokit Esphome"
+    ssid: "Teleinfokit_AP"
     password: #"CHANGE_ME"   # update to a random password
 
 captive_portal:


### PR DESCRIPTION
Some little changes:
* Not necessary to add ESPHome to Teleinfokit as it is for the same project;
* Not sure of the behavior of a Wifi access point with a space inside so also change it and use an underscor
