### PR TITLE
Add classes to sensors

### DIFF
--- a/esphome/teleinfokit.yml
+++ b/esphome/teleinfokit.yml
@@ -52,6 +52,8 @@ sensor:
     name: "hchc"
     unit_of_measurement: "Wh"
     icon: mdi:flash
+    device_class: energy
+    state_class: measurement
     teleinfo_id: myteleinfo
   - platform: teleinfo
     tag_name: "HCHP"
@@ -59,6 +61,8 @@ sensor:
     name: "hchp"
     unit_of_measurement: "Wh"
     icon: mdi:flash
+    device_class: energy
+    state_class: measurement
     teleinfo_id: myteleinfo
   - platform: teleinfo
     tag_name: "PAPP"


### PR DESCRIPTION
* State class to specify it is a measurement sensor
* device_class to specify it is an energy sensor

After more configuration on Home-Assistant side, it could allow to use these sensors with energy integration from Home-Assistant 2021.8

Source: https://community.home-assistant.io/t/home-energy-management-in-2021-8/325539/9