### PR TITLE
Mark the teleinfokit_switch binary sensor internal

### DIFF
--- a/esphome/teleinfokit.yml
+++ b/esphome/teleinfokit.yml
@@ -119,6 +119,7 @@ binary_sensor:
       mode: INPUT_PULLUP
       inverted: True
     name: teleinfokit_switch
+    internal: true
     on_click:
       min_length: 50ms
       max_length: 350ms


### PR DESCRIPTION
As it is used for the physical button, it is not needed to display it for API
Note: for existting installations in Home Assistant, it will make the previously added entity as orphan and the Delete button looks unavailable.
