### PR TITLE
Convert sensors data to kWh

### DIFF
--- a/esphome/teleinfokit.yml
+++ b/esphome/teleinfokit.yml
@@ -107,10 +107,10 @@ display:
           it.printf(0, 0, id(arial_font), "Intensite: %.0f A", id(iinst).state);
       - id: page3
         lambda: |-
-          it.printf(0, 0, id(arial_font), "HP: %.0f", id(hchp).state);
+          it.printf(0, 0, id(arial_font), "HP: %.0f", id(hchp).raw_state);
       - id: page4
         lambda: |-
-          it.printf(0, 0, id(arial_font), "HC: %.0f", id(hchc).state);
+          it.printf(0, 0, id(arial_font), "HC: %.0f", id(hchc).raw_state);
 
 interval:
   - interval: 5s

--- a/esphome/teleinfokit.yml
+++ b/esphome/teleinfokit.yml
@@ -48,20 +48,26 @@ sensor:
     tag_name: "HCHC"
     id: hchc
     name: "Index Heures Creuses"
-    unit_of_measurement: "Wh"
+    unit_of_measurement: "kWh"
+    accuracy_decimals: 3
     icon: mdi:flash
     device_class: energy
     state_class: measurement
     teleinfo_id: myteleinfo
+    filters:
+      - lambda: return x/1000.0;
   - platform: teleinfo
     tag_name: "HCHP"
     id: hchp
     name: "Index Heures Pleines"
-    unit_of_measurement: "Wh"
+    unit_of_measurement: "kWh"
+    accuracy_decimals: 3
     icon: mdi:flash
     device_class: energy
     state_class: measurement
     teleinfo_id: myteleinfo
+    filters:
+      - lambda: return x/1000.0;
   - platform: teleinfo
     tag_name: "PAPP"
     id: papp


### PR DESCRIPTION
It makes integration easyer to Home Assistant energy dashboard, avoiding to create template sensors in Home Assistant where conversion would be made.
In this way utility meters can be directly sourced by ESPHome sensors.
Decimals are displayed to have the most precize measures.
