### PR TITLE
Change filter in kWh conversion

### DIFF
--- a/esphome/teleinfokit.yml
+++ b/esphome/teleinfokit.yml
@@ -55,7 +55,7 @@ sensor:
     state_class: total_increasing
     teleinfo_id: myteleinfo
     filters:
-      - lambda: return x/1000.0;
+      - multiply: 0.001
   - platform: teleinfo
     tag_name: "HCHP"
     id: hchp
@@ -67,7 +67,7 @@ sensor:
     state_class: total_increasing
     teleinfo_id: myteleinfo
     filters:
-      - lambda: return x/1000.0;
+      - multiply: 0.001
   - platform: teleinfo
     tag_name: "PAPP"
     id: papp

--- a/esphome/teleinfokit_bmp.yml
+++ b/esphome/teleinfokit_bmp.yml
@@ -55,7 +55,7 @@ sensor:
     state_class: total_increasing
     teleinfo_id: myteleinfo
     filters:
-      - lambda: return x/1000.0;
+      - multiply: 0.001
   - platform: teleinfo
     tag_name: "HCHP"
     id: hchp
@@ -67,7 +67,7 @@ sensor:
     state_class: total_increasing
     teleinfo_id: myteleinfo
     filters:
-      - lambda: return x/1000.0;
+      - multiply: 0.001
   - platform: teleinfo
     tag_name: "PAPP"
     id: papp


### PR DESCRIPTION
I forgot to submit something in #6 when converting to kWh
As multiply is native to ESPHome and has the same result we have now, there is no reason to use a lambda filter.
